### PR TITLE
Add special page aliases i18n file

### DIFF
--- a/PandocUltimateConverter.alias.php
+++ b/PandocUltimateConverter.alias.php
@@ -1,0 +1,8 @@
+<?php
+
+$specialPageAliases = [];
+
+/** English (English) */
+$specialPageAliases['en'] = [
+	'PandocUltimateConverter' => [ 'PandocUltimateConverter' ],
+];

--- a/extension.json
+++ b/extension.json
@@ -10,6 +10,9 @@
   "AutoloadNamespaces": {
     "MediaWiki\\Extension\\PandocUltimateConverter\\": "includes/"
   },
+  "ExtensionMessagesFiles": {
+    "SpecialPandocUltimateConverter": "PandocUltimateConverter.alias.php"
+  },
   "MessagesDirs": {
     "PandocUltimateConverter": [
       "i18n"


### PR DESCRIPTION
To avoid the 'Did not find alias for special page' warning.